### PR TITLE
Update README for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@ streamlit run app.py
 ```
 
 The app allows you to upload PDFs, which are then chunked into roughly 200–300 word blocks and indexed in Pinecone under the namespace you provide. You can then ask questions, and the app will return the top three most relevant text chunks along with similarity scores.
+
+## Deploying to Vercel
+
+The project includes a small Next.js frontend located in `src/`. Vercel provides
+first‑class support for Next.js and can deploy it directly from this
+repository.
+
+1. [Install the Vercel CLI](https://vercel.com/docs/cli) and run `vercel` in the
+   repository root. Follow the prompts to create a new Vercel project.
+2. In the Vercel dashboard set the same environment variables used locally
+   (`OPENAI_API_KEY`, `PINECONE_API_KEY`, `PINECONE_ENV` and `PINECONE_INDEX`).
+3. Commit and push your code to the linked Git repository. Vercel will
+   automatically build and deploy the Next.js frontend.
+
+The Streamlit application is not designed to run on Vercel and should be hosted
+separately (for example on Streamlit Community Cloud or another Python‑friendly
+platform).


### PR DESCRIPTION
## Summary
- document how to deploy the Next.js portion to Vercel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68430474a2548330b8a8468e5be945ab